### PR TITLE
Release 3.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ php:
 env:
   global:
     - LATEST_PHP_VERSION="7.2"
-    - MAINTAINED_SYMFONY_VERSIONS="2.8.*|3.4.*|4.0.*|4.1.*"
+    - MAINTAINED_SYMFONY_VERSIONS="2.8.*|3.4.*|4.0.*|4.1.*|4.2.*"
   matrix:
     - SYMFONY_VERSION="2.8.*"
     - SYMFONY_VERSION="3.0.*"
@@ -24,6 +24,7 @@ env:
     - SYMFONY_VERSION="3.4.*"
     - SYMFONY_VERSION="4.0.*"
     - SYMFONY_VERSION="4.1.*"
+    - SYMFONY_VERSION="4.2.*"
     - SYMFONY_VERSION="dev-master"
     - DEPENDENCIES="beta"
     - DEPENDENCIES="low"

--- a/composer.json
+++ b/composer.json
@@ -33,10 +33,10 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "*",
         "jakub-onderka/php-parallel-lint": "^1.0",
+        "php-coveralls/php-coveralls": "^2.1",
         "phpstan/phpstan": "^0.10.2",
         "phpstan/phpstan-phpunit": "^0.10.0",
         "phpunit/phpunit": "^7.2",
-        "satooshi/php-coveralls": "^2.0",
         "sensiolabs/security-checker": "^4.1",
         "symfony/phpunit-bridge": "^3.0|^4.0"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,11 +6,10 @@
         convertWarningsToExceptions="true"
         stopOnFailure="false"
         bootstrap="vendor/autoload.php"
-        verbose="true"
-        syntaxCheck="true">
+        verbose="true">
 
     <testsuites>
-        <testsuite>
+        <testsuite name="SocialPost Bundle Test Suite">
             <directory>./tests</directory>
         </testsuite>
     </testsuites>

--- a/src/MartinGeorgiev/SocialPostBundle/DependencyInjection/Configuration.php
+++ b/src/MartinGeorgiev/SocialPostBundle/DependencyInjection/Configuration.php
@@ -17,8 +17,8 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('social_post');
+        $treeBuilder = new TreeBuilder('social_post');
+        $rootNode = $treeBuilder->getRootNode($treeBuilder, 'social_post');
 
         $rootNode
             ->children()


### PR DESCRIPTION
- Fix Symfony 4.2 deprecations for TreeBuilder
- Fix PHPUnit deprecations for the configuration file
- Replace dev dependency of satooshi/php-coveralls with php-coveralls/php-coveralls