### PR TITLE
Update CI checks

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,3 +1,7 @@
+build:
+  environment:
+    php: 7.3
+
 coding_style:
   php:
     spaces:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,15 @@ cache:
 php:
   - 7.1
   - 7.2
+  - 7.3
   - nightly
 
 env:
   global:
-    - LATEST_PHP_VERSION="7.2"
-    - MAINTAINED_SYMFONY_VERSIONS="2.8.*|3.4.*|4.0.*|4.1.*|4.2.*"
+    - LATEST_PHP_VERSION="7.3"
+    - MAINTAINED_SYMFONY_VERSIONS="2.8.*|3.4.*|4.1.*|4.2.*"
   matrix:
     - SYMFONY_VERSION="2.8.*"
-    - SYMFONY_VERSION="3.0.*"
-    - SYMFONY_VERSION="3.1.*"
-    - SYMFONY_VERSION="3.2.*"
-    - SYMFONY_VERSION="3.3.*"
     - SYMFONY_VERSION="3.4.*"
     - SYMFONY_VERSION="4.0.*"
     - SYMFONY_VERSION="4.1.*"
@@ -46,6 +43,9 @@ before_install:
   - mkdir -p build/logs
 
 install:
+  - if [ "$(phpenv version-name)" != "$LATEST_PHP_VERSION" ]; then
+      composer remove friendsofphp/php-cs-fixer phpstan/phpstan phpstan/phpstan-phpunit --dev;
+    fi
   - if [ "$DEPENDENCIES" = "beta" ]; then
       composer config minimum-stability beta;
       composer update -n --prefer-dist;
@@ -63,6 +63,11 @@ script:
       echo "File validation is skipped for older PHP versions";
     else
       composer validate-files;
+    fi;
+  - if [ "$(phpenv version-name)" != "$LATEST_PHP_VERSION" ]; then
+      echo "Static analysis is skipped for older PHP versions";
+    else
+      composer run-static-analysis-including-tests;
     fi;
   - if [ "$(phpenv version-name)" != "$LATEST_PHP_VERSION" ]; then
       echo "Code style check is skipped for older PHP versions";

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "MartinGeorgiev\\Tests\\": "tests/MartinGeorgiev/"
+            "Tests\\MartinGeorgiev\\": "tests/MartinGeorgiev/"
         }
     },
 
@@ -34,38 +34,38 @@
         "friendsofphp/php-cs-fixer": "*",
         "jakub-onderka/php-parallel-lint": "^1.0",
         "php-coveralls/php-coveralls": "^2.1",
-        "phpstan/phpstan": "^0.10.2",
-        "phpstan/phpstan-phpunit": "^0.10.0",
-        "phpunit/phpunit": "^7.2",
-        "sensiolabs/security-checker": "^4.1",
+        "phpstan/phpstan": "^0.11",
+        "phpstan/phpstan-phpunit": "^0.11",
+        "phpunit/phpunit": "^8.1",
+        "sensiolabs/security-checker": "^5.0",
         "symfony/phpunit-bridge": "^3.0|^4.0"
     },
 
     "scripts": {
         "check-code-style": [
-            "bin/php-cs-fixer fix --config='./.php_cs' --show-progress=none --dry-run --no-interaction --diff -v"
+            "php-cs-fixer fix --config='./.php_cs' --show-progress=none --dry-run --no-interaction --diff -v"
         ],
         "check-security": [
-            "bin/security-checker security:check"
+            "security-checker security:check"
         ],
         "fix-code-style": [
-            "bin/php-cs-fixer fix --config='./.php_cs' --show-progress=none --no-interaction --diff -v"
+            "php-cs-fixer fix --config='./.php_cs' --show-progress=none --no-interaction --diff -v"
         ],
         "run-static-analysis": [
-            "bin/phpstan analyse --level=7 src/"
+            "phpstan analyse --level=7 src/"
         ],
         "run-static-analysis-including-tests": [
             "@run-static-analysis",
-            "bin/phpstan analyse --level=4 tests/"
+            "phpstan analyse --level=7 tests/"
         ],
         "run-tests": [
-            "bin/phpunit"
+            "phpunit"
         ],
         "run-tests-with-clover": [
-            "bin/phpunit --coverage-clover build/logs/clover.xml"
+            "phpunit --coverage-clover build/logs/clover.xml"
         ],
         "validate-files": [
-            "bin/parallel-lint --exclude vendor --exclude bin ."
+            "parallel-lint --exclude vendor --exclude bin ."
         ]
     },
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,2 +1,12 @@
 includes:
-  - vendor/phpstan/phpstan-phpunit/extension.neon
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+
+parameters:
+    autoload_directories:
+        - %rootDir%/../../../src
+        - %rootDir%/../../../tests
+
+    reportUnmatchedIgnoredErrors: false
+    ignoreErrors:
+        - '#Cannot call method scalarNode() on Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface|null#'
+        - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::children().#'

--- a/tests/MartinGeorgiev/SocialPostBundle/DependecyInjection/SocialPostExtensionTest.php
+++ b/tests/MartinGeorgiev/SocialPostBundle/DependecyInjection/SocialPostExtensionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MartinGeorgiev\Tests\SocialPostBundle\DependencyInjection;
+namespace Tests\MartinGeorgiev\SocialPostBundle\DependencyInjection;
 
 use MartinGeorgiev\SocialPostBundle\DependencyInjection\SocialPostExtension;
 use PHPUnit\Framework\TestCase;

--- a/tests/MartinGeorgiev/SocialPostBundle/SocialPostBundleTest.php
+++ b/tests/MartinGeorgiev/SocialPostBundle/SocialPostBundleTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MartinGeorgiev\Tests\SocialPostBundle;
+namespace Tests\MartinGeorgiev\SocialPostBundle;
 
 use MartinGeorgiev\SocialPostBundle\DependencyInjection\Compiler\AllInOnePass;
 use MartinGeorgiev\SocialPostBundle\SocialPostBundle;


### PR DESCRIPTION
- Adds 7.3 as latest PHP version
- Adds static analysis step to the pipeline
- Drops from the matrix Symfony versions 3.0 to 3.3 as not maintained anymore
- Updates the minimum version for PHPUnit, PHPStan and the security checker
- Refactors the tests namespace